### PR TITLE
[WIP]create_front_view フロント画面の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,3 +52,4 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'haml-rails'
+gem 'font-awesome-sass'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,8 @@ GEM
     erubis (2.7.0)
     execjs (2.7.0)
     ffi (1.11.2)
+    font-awesome-sass (5.11.2)
+      sassc (>= 1.11)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     haml (5.1.2)
@@ -138,6 +140,8 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    sassc (2.2.1)
+      ffi (~> 1.9)
     sexp_processor (4.13.0)
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
@@ -176,6 +180,7 @@ PLATFORMS
 DEPENDENCIES
   byebug
   coffee-rails (~> 4.2)
+  font-awesome-sass
   haml-rails
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/assets/stylesheets/_messages.scss
+++ b/app/assets/stylesheets/_messages.scss
@@ -1,0 +1,199 @@
+html, body {
+  height: 100%;
+  margin: 0;
+  padding: 0;
+}
+
+$chatWhiteColor: #fff;
+$chatBlueColor: #38aef0;
+
+* {
+  box-sizing: border-box;
+}
+
+a {
+  text-decoration: none;
+}
+
+li {
+  display: list-item;
+}
+
+p {
+  display: block;
+}
+
+*::-webkit-scrollbar {
+  display: none;
+}
+
+.wrapper {
+  display: flex;
+}
+
+.chat-side {
+  width: 300px;
+  color: $chatWhiteColor;
+  float: left;
+  font-weight: bold;
+
+  a {
+    color: $chatWhiteColor;
+  }
+  .side-header {
+    background-color: #253141;
+    height: 100px;
+    display: flex;
+    align-items: center;
+    padding: 0 20px;
+
+    &__box {
+      display: flex;
+      justify-content: space-between;
+      width: 100%;
+      font-size: 16px;
+      
+      &--menu {
+        display: flex;
+
+        &__new-group {
+          margin-left: 0.3rem;
+        }
+        &__edit-group {
+          margin-left: 0.3rem;
+        }
+      }
+    }
+  }
+
+  .groups {
+    background-color: #2f3e51;
+    height: calc(100vh - 100px);
+    padding: 20px 20px 0 ;
+    overflow: scroll;
+
+    .group {
+      margin-bottom: 40px;
+
+      &__group-name {
+        font-size: 15px;
+        margin-bottom: 5px;
+      }
+      &__group-latest-message {
+        font-size: 11px;
+      }
+    }
+  }
+}
+
+.chat-main {
+  width: calc(100vw - 300px);
+  float: left;
+
+  .main-header {
+    height: 100px;
+    padding: 0 40px;
+    display: flex;
+    justify-content: space-between;
+    border-bottom: solid 1px #eee;
+    overflow: scroll;
+
+    &__left-box {
+      margin-top: 35px;
+      &__current-group {
+        font-size: 20px;
+        color: #333;
+        margin-bottom: 15px;
+      }
+      &__menber-list {
+        display: flex;
+        font-size: 12px;
+        color: #999999;
+      }
+    }
+    a:visited {
+      color: $chatBlueColor;
+    }
+    &__edit-btn {
+      height: 40px;
+      line-height: 40px;
+      padding: 0 20px;
+      margin-top: 30px;
+      border: solid 1px $chatBlueColor;
+      right: 40px;
+    }
+  }
+
+  .messages {
+    height: calc(100vh - 190px);
+    padding: 46px 40px;
+    background-color: #fafafa;
+    overflow: scroll;
+
+    .message {
+      padding-bottom: 40px;
+      color: #434a54;
+
+      &__upper-info {
+        display: flex;
+        margin-bottom: 10px;
+
+        &__talker {
+          font-size: 16px;
+          font-weight: bold;
+        }
+        &__date {
+          color: #999999;
+          font-size: 12px;
+          margin-left: 10px;
+        }
+      }
+      &__text {
+        font-size: 14px;
+        margin-bottom: 10px;
+      }
+    }
+  }
+
+  .form {
+    height: 90px;
+    padding: 20px 40px;
+    background-color: #ddd;
+
+    .new_message {
+      display: flex;
+    }
+      .input-box {
+        position: relative;
+        width: 100%;
+        
+        &__text {
+          height: 50px;
+          width: 100%;
+          padding: 0 40px 0 10px;
+          color: #434a54;
+          border-style: none;
+        }
+        &__image {
+          font-size: 1.3rem;
+          position: absolute;
+          top: 10px;
+          right: 10px;
+          cursor: pointer;
+          
+          &__file {
+            display: none;
+          }
+        }
+      }
+      .submit-btn {
+        width: 100px;
+        height: 50px;
+        padding: 0 30px;
+        margin-left: 15px;
+        background-color: $chatBlueColor;
+        color: $chatWhiteColor;
+        cursor: pointer;
+      }
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,1 +1,4 @@
 @import "./reset";
+@import "font-awesome-sprockets";
+@import "./font-awesome";
+@import "messages";

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,7 +1,7 @@
 !!!
 %html
   %head
-    %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
+    %meta{content: "text/html; charset=UTF-8", "http-equiv": "Content-Type"}/
     %title ChatSpace
     = csrf_meta_tags
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -1,0 +1,32 @@
+.chat-main
+  .main-header
+    .main-header__left-box
+      %h2.main-header__left-box__current-group current-group
+      %ul.main-header__left-box__menber-list
+        Menber：
+        %li.main-header__left-box__menber-list__menber list_menber
+    =link_to "#" do
+      .main-header__edit-btn Edit
+
+  .messages
+    .message
+      .message__upper-info
+        %p.message__upper-info__talker talker1
+        %p.message__upper-info__date 2019/11/22(Fri) 12:46:41
+      %p.message__text text1
+    .message
+      .message__upper-info
+        %p.message__upper-info__talker talker2
+        %p.message__upper-info__date 2019/11/22(Fri) 12:46:42
+      %p.message__text text2
+
+  .form
+    %form.new_message{ id: "new_message", action: "#", method: "post", enctype: "multipart/form-data"}
+      %input{name: "utf-8",type: "hidden"}
+      %input{name: "authenticity_token",type: "hidden"}
+      .input-box
+        %input.input-box__text{placeholder: "type a message", type: "text", name: "message[content]", id: "message_content"}
+        %label.input-box__image{for: "message_image"}
+          = icon('fas', 'image')
+          %input.input-box__image__file{type: "file", name: "message[image]", id: "message_image"}
+      %input.submit-btn{type: "submit", name: "commit",value: "Send"}

--- a/app/views/messages/_side_bar.html.haml
+++ b/app/views/messages/_side_bar.html.haml
@@ -1,0 +1,16 @@
+.chat-side
+  .side-header
+    .side-header__box
+      %p.side-header__box--user-name side-header__box--user-name
+      %ul.side-header__box--menu
+        %li.side-header__box--menu__new-group
+          =link_to "#" do
+            = icon('fas', 'edit')
+        %li.side-header__box--menu__edit-group
+          =link_to "#" do
+            = icon('fas', 'cog')
+  .groups
+    .group
+      %p.group__group-name group__group-name
+      %p.group__group-latest-message group__group-latest-message
+


### PR DESCRIPTION
# What
Chatspaceのフロント画面の実装を行った。index.html.hamlを_side_bar.html.hamlと_main_chat.html.hamlの部分でrenderメソッドを用いて部分テンプレートを用いた。また、application.scssを_messages.scssに部分テンプレートを用いた

# Why
クライアントに情報入力をしてもらう画面のコードについて誤りが無いかレビューしていただく思います。
よろしくお願いいたします。

![1E39E6D0-9577-4C41-8997-CD7C8A12D6A3_1_105_c](https://user-images.githubusercontent.com/57927432/69408624-beea7980-0d4a-11ea-8ea5-3ad8fb48b352.jpeg)
