### PR TITLE
[WIP]create_group-editing-function2

### DIFF
--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -1,3 +1,2 @@
 .wrapper
   = render 'shared/side_bar'
-  = render "shared/main_chat"

--- a/app/views/shared/_side_bar.html.haml
+++ b/app/views/shared/_side_bar.html.haml
@@ -13,7 +13,7 @@
   .groups
     - current_user.groups.each do |group|
       .group
-        = link_to '#' do
+        = link_to group_messages_path(group) do
           %p.group__group-name 
             = group.name
           %p.group__group-latest-message


### PR DESCRIPTION
# What
1. groupsコントーローラーのindexアクションviewファイルにて、shared/main_chatの部分テンプレートを解除した。
2. groupsコントーローラーのindexアクションviewファイルにて、グループ名をクリックした時にグループのチャット画面がみれるよう編集した

# Why 
[WIP]create_group-editing-functionのプルリクエストの機能追加漏れのため